### PR TITLE
force the script to use the current subscription

### DIFF
--- a/Logic-Apps/Find-Azure-Orphaned-API-Connectors-powershell/Find-Orphaned-API-Connectors.ps1
+++ b/Logic-Apps/Find-Azure-Orphaned-API-Connectors-powershell/Find-Orphaned-API-Connectors.ps1
@@ -29,6 +29,7 @@ Connect-AzAccount
 $subscription = Get-AzSubscription -SubscriptionName $subscriptioName
 $subscriptionId = $subscription.Id
 Write-Host 'Subscription Id: ' $subscriptionId
+Select-AzSubscription -SubscriptionId $subscriptionId
 
 #########################################################
 # Get Resource Group Info


### PR DESCRIPTION
In the case when you have more than one subscription the script stick to the default subscription set in Azure profile even if I have provided a different subscription name. 
I have updated the script to force to use the selected subscription. 
Thanks,